### PR TITLE
Adding .NET Standard projects

### DIFF
--- a/NSpeedTest.Standard/ISpeedTestClient.cs
+++ b/NSpeedTest.Standard/ISpeedTestClient.cs
@@ -1,0 +1,32 @@
+﻿using NSpeedTest.Models;
+using System.Threading.Tasks;
+
+namespace NSpeedTest
+{
+    public interface ISpeedTestClient
+    {
+        /// <summary>
+        /// Download speedtest.net settings
+        /// </summary>
+        /// <returns>speedtest.net settings</returns>
+        Task<Settings> GetSettings();
+
+        /// <summary>
+        /// Test latency (ping) to server
+        /// </summary>
+        /// <returns>Latency in milliseconds (ms)</returns>
+        Task<int> TestServerLatency(Server server, int retryCount = 3);
+
+        /// <summary>
+        /// Test download speed to server
+        /// </summary>
+        /// <returns>Download speed in Kbps</returns>
+        double TestDownloadSpeed(Server server, int simultaniousDownloads = 2, int retryCount = 2);
+
+        /// <summary>
+        /// Test upload speed to server
+        /// </summary>
+        /// <returns>Upload speed in Kbps</returns>
+        double TestUploadSpeed(Server server, int simultaniousUploads = 2, int retryCount = 2);
+    }
+}

--- a/NSpeedTest.Standard/Models/Client.cs
+++ b/NSpeedTest.Standard/Models/Client.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("client")]
+    public class Client
+    {
+        [XmlAttribute("ip")]
+        public string Ip { get; set; }
+
+        [XmlAttribute("lat")]
+        public double Latitude { get; set; }
+
+        [XmlAttribute("lon")]
+        public double Longitude { get; set; }
+
+        [XmlAttribute("isp")]
+        public string Isp { get; set; }
+
+        [XmlAttribute("isprating")]
+        public double IspRating { get; set; }
+
+        [XmlAttribute("rating")]
+        public double Rating { get; set; }
+
+        [XmlAttribute("ispdlavg")]
+        public int IspAvarageDownloadSpeed { get; set; }
+
+        [XmlAttribute("ispulavg")]
+        public int IspAvarageUploadSpeed { get; set; }
+
+        private readonly Lazy<Coordinate> geoCoordinate;
+
+        public Coordinate GeoCoordinate
+        {
+            get { return geoCoordinate.Value; }
+        }
+
+        public Client()
+        {
+            // note: geo coordinate will not be recalculated on Latitude or Longitude change
+            geoCoordinate = new Lazy<Coordinate>(() => new Coordinate(Latitude, Longitude));
+        }
+    }
+}

--- a/NSpeedTest.Standard/Models/Coordinate.cs
+++ b/NSpeedTest.Standard/Models/Coordinate.cs
@@ -1,0 +1,34 @@
+﻿using System;
+
+namespace NSpeedTest.Models
+{
+    public class Coordinate
+    {
+        public double Latitude { get; private set; }
+        public double Longitude { get; private set; }
+
+        public Coordinate(double latitude, double longitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+        }
+
+        public double GetDistanceTo(Coordinate other)
+        {
+            if (double.IsNaN(Latitude) || double.IsNaN(Longitude) || double.IsNaN(other.Latitude) ||
+                double.IsNaN(other.Longitude))
+            {
+                throw new ArgumentException("Argument latitude or longitude is not a number");
+            }
+
+            var d1 = Latitude * (Math.PI / 180.0);
+            var num1 = Longitude * (Math.PI / 180.0);
+            var d2 = other.Latitude * (Math.PI / 180.0);
+            var num2 = other.Longitude * (Math.PI / 180.0) - num1;
+            var d3 = Math.Pow(Math.Sin((d2 - d1) / 2.0), 2.0) +
+                     Math.Cos(d1) * Math.Cos(d2) * Math.Pow(Math.Sin(num2 / 2.0), 2.0);
+
+            return 6376500.0 * (2.0 * Math.Atan2(Math.Sqrt(d3), Math.Sqrt(1.0 - d3)));
+        }
+    }
+}

--- a/NSpeedTest.Standard/Models/Download.cs
+++ b/NSpeedTest.Standard/Models/Download.cs
@@ -1,0 +1,20 @@
+﻿using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("download")]
+    public class Download
+    {
+        [XmlAttribute("testlength")]
+        public int TestLength { get; set; }
+
+        [XmlAttribute("initialtest")]
+        public string InitialTest { get; set; }
+
+        [XmlAttribute("mintestsize")]
+        public string MinTestSize { get; set; }
+
+        [XmlAttribute("threadsperurl")]
+        public int ThreadsPerUrl { get; set; }
+    }
+}

--- a/NSpeedTest.Standard/Models/Server.cs
+++ b/NSpeedTest.Standard/Models/Server.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("server")]
+    public class Server
+    {
+        [XmlAttribute("id")]
+        public int Id { get; set; }
+
+        [XmlAttribute("name")]
+        public string Name { get; set; }
+
+        [XmlAttribute("country")]
+        public string Country { get; set; }
+
+        [XmlAttribute("sponsor")]
+        public string Sponsor { get; set; }
+
+        [XmlAttribute("host")]
+        public string Host { get; set; }
+
+        [XmlAttribute("url")]
+        public string Url { get; set; }
+
+        [XmlAttribute("lat")]
+        public double Latitude { get; set; }
+
+        [XmlAttribute("lon")]
+        public double Longitude { get; set; }
+
+        public double Distance { get; set; }
+
+        public int Latency { get; set; }
+
+        private Lazy<Coordinate> geoCoordinate;
+        public Coordinate GeoCoordinate
+        {
+            get { return geoCoordinate.Value; }
+        }
+
+        public Server()
+        {
+            // note: geo coordinate will not be recalculated on Latitude or Longitude change
+            geoCoordinate = new Lazy<Coordinate>(() => new Coordinate(Latitude, Longitude));
+        }
+    }
+}

--- a/NSpeedTest.Standard/Models/ServerConfig.cs
+++ b/NSpeedTest.Standard/Models/ServerConfig.cs
@@ -1,0 +1,11 @@
+﻿using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("server-config")]
+    public class ServerConfig
+    {
+        [XmlAttribute("ignoreids")]
+        public string IgnoreIds { get; set; }
+    }
+}

--- a/NSpeedTest.Standard/Models/ServersList.cs
+++ b/NSpeedTest.Standard/Models/ServersList.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("settings")]
+    public class ServersList
+    {
+        [XmlArray("servers")]
+        [XmlArrayItem("server")]
+        public List<Server> Servers { get; set; }
+
+        public ServersList()
+        {
+            Servers = new List<Server>();
+        }
+
+        public void CalculateDistances(Coordinate clientCoordinate)
+        {
+            foreach (var server in Servers)
+            {
+                server.Distance = clientCoordinate.GetDistanceTo(server.GeoCoordinate);
+            }
+        }
+    }
+}

--- a/NSpeedTest.Standard/Models/Settings.cs
+++ b/NSpeedTest.Standard/Models/Settings.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("settings")]
+    public class Settings
+    {
+        [XmlElement("client")]
+        public Client Client { get; set; }
+
+        [XmlElement("times")]
+        public Times Times { get; set; }
+
+        [XmlElement("download")]
+        public Download Download { get; set; }
+
+        [XmlElement("upload")]
+        public Upload Upload { get; set; }
+
+        [XmlElement("server-config")]
+        public ServerConfig ServerConfig { get; set; }
+
+        public List<Server> Servers { get; set; }
+
+        public Settings()
+        {
+            Servers = new List<Server>();
+        }
+    }
+}

--- a/NSpeedTest.Standard/Models/Times.cs
+++ b/NSpeedTest.Standard/Models/Times.cs
@@ -1,0 +1,26 @@
+﻿using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("times")]
+    public class Times
+    {
+        [XmlAttribute("dl1")]
+        public int Download1 { get; set; }
+
+        [XmlAttribute("dl2")]
+        public int Download2 { get; set; }
+
+        [XmlAttribute("dl3")]
+        public int Download3 { get; set; }
+
+        [XmlAttribute("ul1")]
+        public int Upload1 { get; set; }
+
+        [XmlAttribute("ul2")]
+        public int Upload2 { get; set; }
+
+        [XmlAttribute("ul3")]
+        public int Upload3 { get; set; }
+    }
+}

--- a/NSpeedTest.Standard/Models/Upload.cs
+++ b/NSpeedTest.Standard/Models/Upload.cs
@@ -1,0 +1,32 @@
+﻿using System.Xml.Serialization;
+
+namespace NSpeedTest.Models
+{
+    [XmlRoot("upload")]
+    public class Upload
+    {
+        [XmlAttribute("testlength")]
+        public int TestLength { get; set; }
+
+        [XmlAttribute("ratio")]
+        public int Ratio { get; set; }
+
+        [XmlAttribute("initialtest")]
+        public int InitialTest { get; set; }
+
+        [XmlAttribute("mintestsize")]
+        public string MinTestSize { get; set; }
+
+        [XmlAttribute("threads")]
+        public int Threads { get; set; }
+
+        [XmlAttribute("maxchunksize")]
+        public string MaxChunkSize { get; set; }
+
+        [XmlAttribute("maxchunkcount")]
+        public string MaxChunkCount { get; set; }
+
+        [XmlAttribute("threadsperurl")]
+        public int ThreadsPerUrl { get; set; }
+    }
+}

--- a/NSpeedTest.Standard/NSpeedTest.Standard.csproj
+++ b/NSpeedTest.Standard/NSpeedTest.Standard.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.6</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="1.1.1" />
+    <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
+    <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/NSpeedTest.Standard/NSpeedTest.nuspec
+++ b/NSpeedTest.Standard/NSpeedTest.nuspec
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>$id$</id>
+    <version>1.2</version>
+    <title>$title$</title>
+    <authors>Uladzimir Kazakevich</authors>
+    <owners>Uladzimir Kazakevich</owners>
+    <licenseUrl>https://raw.githubusercontent.com/Kwull/NSpeedTest/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/kwull/nspeedtest</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>NSpeedTest client library to test internet bandwidth using speedtest.net</description>
+    <copyright>Copyright 2017</copyright>
+    <tags>SpeedTest speedtest.net</tags>
+  </metadata>
+</package>

--- a/NSpeedTest.Standard/SpeedTestClient.cs
+++ b/NSpeedTest.Standard/SpeedTestClient.cs
@@ -1,0 +1,189 @@
+﻿using NSpeedTest.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace NSpeedTest
+{
+    public class SpeedTestClient : ISpeedTestClient
+    {
+        private const string ConfigUrl = "http://www.speedtest.net/speedtest-config.php";
+        private const string ServersUrl = "http://www.speedtest.net/speedtest-servers.php";
+        //private readonly int[] downloadSizes = { 350, 500, 750, 1000, 1500, 2000, 2500, 3000, 3500, 4000 };
+        private readonly int[] downloadSizes = { 350, 750, 1500 };
+        private const string Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        private const int MaxUploadSize = 4; // 400 KB
+
+        #region ISpeedTestClient
+
+        /// <summary>
+        /// Download speedtest.net settings
+        /// </summary>
+        /// <returns>speedtest.net settings</returns>
+        public async Task<Settings> GetSettings()
+        {
+            using (var client = new SpeedTestWebClient())
+            {
+                var settings = await client.GetConfig<Settings>(ConfigUrl);
+                var serversConfig = await client.GetConfig<ServersList>(ServersUrl);
+
+                serversConfig.CalculateDistances(settings.Client.GeoCoordinate);
+                settings.Servers = serversConfig.Servers.OrderBy(s => s.Distance).ToList();
+
+                return settings;
+            }
+        }
+
+        /// <summary>
+        /// Test latency (ping) to server
+        /// </summary>
+        /// <returns>Latency in milliseconds (ms)</returns>
+        public async Task<int> TestServerLatency(Server server, int retryCount = 3)
+        {
+            var latencyUri = CreateTestUrl(server, "latency.txt");
+            var timer = new Stopwatch();
+
+            using (var client = new SpeedTestWebClient())
+            {
+                for (var i = 0; i < retryCount; i++)
+                {
+                    string testString;
+                    try
+                    {
+                        timer.Start();
+                        testString = await client.GetStringAsync(latencyUri);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
+                    finally
+                    {
+                        timer.Stop();    
+                    }
+
+                    if (!testString.StartsWith("test=test"))
+                    {
+                        throw new InvalidOperationException("Server returned incorrect test string for latency.txt");
+                    }
+                }
+            }
+
+            return (int)timer.ElapsedMilliseconds / retryCount;
+        }
+
+        /// <summary>
+        /// Test download speed to server
+        /// </summary>
+        /// <returns>Download speed in Kbps</returns>
+        public double TestDownloadSpeed(Server server, int simultaneousDownloads = 2, int retryCount = 2)
+        {
+            var testData = GenerateDownloadUrls(server, retryCount);
+
+            return TestSpeed(testData, async (client, url) =>
+            {
+                var data = await client.GetStringAsync(url).ConfigureAwait(false);
+                return data.Length;
+            }, simultaneousDownloads);
+        }
+
+        /// <summary>
+        /// Test upload speed to server
+        /// </summary>
+        /// <returns>Upload speed in Kbps</returns>
+        public double TestUploadSpeed(Server server, int simultaneousUploads = 2, int retryCount = 2)
+        {
+            var testData = GenerateUploadData(retryCount);
+            return TestSpeed(testData, async (client, uploadData) =>
+            {
+                var data = new List<KeyValuePair<string, string>>();
+                foreach (var k in uploadData.AllKeys)
+                {
+                    data.Add(new KeyValuePair<string, string>(k, uploadData[k]));
+                }
+                await client.PostAsync(server.Url, new FormUrlEncodedContent(data)).ConfigureAwait(false);
+                return uploadData[0].Length;
+            }, simultaneousUploads);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static double TestSpeed<T>(IEnumerable<T> testData, Func<HttpClient, T, Task<int>> doWork, int concurencyCount = 2)
+        {
+            var timer = new Stopwatch();
+            var throttler = new SemaphoreSlim(concurencyCount);
+
+            timer.Start();
+            var downloadTasks = testData.Select(async data =>
+            {
+                await throttler.WaitAsync().ConfigureAwait(false);
+                var client = new SpeedTestWebClient();
+                try
+                {
+                    var size = await doWork(client, data).ConfigureAwait(false);
+                    return size;
+                }
+                finally
+                {
+                    client.Dispose();
+                    throttler.Release();
+                }
+            }).ToArray();
+
+            Task.WaitAll(downloadTasks);
+            timer.Stop();
+
+            double totalSize = downloadTasks.Sum(task => task.Result);
+            return (totalSize * 8 / 1024) / ((double)timer.ElapsedMilliseconds / 1000);
+        }
+
+        private static IEnumerable<NameValueCollection> GenerateUploadData(int retryCount)
+        {
+            var random = new Random();
+            var result = new List<NameValueCollection>();
+
+            for (var sizeCounter = 1; sizeCounter < MaxUploadSize+1; sizeCounter++)
+            {
+                var size = sizeCounter*200*1024;
+                var builder = new StringBuilder(size);
+
+                for (var i = 0; i < size; ++i)
+                    builder.Append(Chars[random.Next(Chars.Length)]);
+
+                for (var i = 0; i < retryCount; i++)
+                {
+                    result.Add(new NameValueCollection { { string.Format("content{0}", sizeCounter), builder.ToString() } });
+                }
+            }
+
+            return result;
+        }
+
+        private static string CreateTestUrl(Server server, string file)
+        {
+            return new Uri(new Uri(server.Url), ".").OriginalString + file;
+        }
+
+        private IEnumerable<string> GenerateDownloadUrls(Server server, int retryCount)
+        {
+            var downloadUriBase = CreateTestUrl(server, "random{0}x{0}.jpg?r={1}");
+            foreach (var downloadSize in downloadSizes)
+            {
+                for (var i = 0; i < retryCount; i++)
+                {
+                    yield return string.Format(downloadUriBase, downloadSize, i);
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/NSpeedTest.Standard/SpeedTestWebClient.cs
+++ b/NSpeedTest.Standard/SpeedTestWebClient.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.WebUtilities;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace NSpeedTest
+{
+    internal class SpeedTestWebClient : HttpClient
+    {
+        public int ConnectionLimit { get; set; }
+
+        public SpeedTestWebClient()
+        {
+            ConnectionLimit = 10;
+        }
+
+        public async Task<T> GetConfig<T>(string url)
+        {
+            var data = await GetStringAsync(url);
+            var xmlSerializer = new XmlSerializer(typeof(T));
+            using (var reader = new StringReader(data))
+            {
+                return (T)xmlSerializer.Deserialize(reader);
+            }
+        }
+
+        private static Uri AddTimeStamp(Uri address)
+        {
+            var uriBuilder = new UriBuilder(address);
+            var query = QueryHelpers.ParseQuery(uriBuilder.Query);
+            query["x"] = DateTime.Now.ToFileTime().ToString(CultureInfo.InvariantCulture);
+            uriBuilder.Query = query.ToString();
+            return uriBuilder.Uri;
+        }
+    }
+}

--- a/NSpeedTest.StandardClient/NSpeedTest.StandardClient.csproj
+++ b/NSpeedTest.StandardClient/NSpeedTest.StandardClient.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NSpeedTest.Standard\NSpeedTest.Standard.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/NSpeedTest.StandardClient/Program.cs
+++ b/NSpeedTest.StandardClient/Program.cs
@@ -14,10 +14,11 @@ namespace NSpeedTest.Client
 
         static void Main()
         {
-            Setup();
+            MainAsync().GetAwaiter().GetResult();
+            Console.ReadKey();
         }
 
-        private static async void Setup()
+        private static async Task MainAsync()
         {
             Console.WriteLine("Getting speedtest.net settings and server list...");
             client = new SpeedTestClient();

--- a/NSpeedTest.StandardClient/Program.cs
+++ b/NSpeedTest.StandardClient/Program.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NSpeedTest.Models;
+using System.Threading.Tasks;
+
+namespace NSpeedTest.Client
+{
+    class Program
+    {
+        private static SpeedTestClient client;
+        private static Settings settings;
+        private const string DefaultCountry = "Belarus";
+
+        static void Main()
+        {
+            Setup();
+        }
+
+        private static async void Setup()
+        {
+            Console.WriteLine("Getting speedtest.net settings and server list...");
+            client = new SpeedTestClient();
+            settings = await client.GetSettings();
+
+            var servers = await SelectServers();
+            var bestServer = SelectBestServer(servers);
+
+            Console.WriteLine("Testing speed...");
+            var downloadSpeed = client.TestDownloadSpeed(bestServer, settings.Download.ThreadsPerUrl);
+            PrintSpeed("Download", downloadSpeed);
+            var uploadSpeed = client.TestUploadSpeed(bestServer, settings.Upload.ThreadsPerUrl);
+            PrintSpeed("Upload", uploadSpeed);
+
+            Console.WriteLine("Press a key to exit.");
+            Console.ReadKey();
+        }
+
+        private static Server SelectBestServer(IEnumerable<Server> servers)
+        {
+            Console.WriteLine();
+            Console.WriteLine("Best server by latency:");
+            var bestServer = servers.OrderBy(x => x.Latency).First();
+            PrintServerDetails(bestServer);
+            Console.WriteLine();
+            return bestServer;
+        }
+
+        private static async Task<IEnumerable<Server>> SelectServers()
+        {
+            Console.WriteLine();
+            Console.WriteLine("Selecting best server by distance...");
+            var servers = settings.Servers.Where(s => s.Country.Equals(DefaultCountry)).Take(10).ToList();
+
+            foreach (var server in servers)
+            {
+                server.Latency = await client.TestServerLatency(server);
+                PrintServerDetails(server);
+            }
+            return servers;
+        }
+
+        private static void PrintServerDetails(Server server)
+        {
+            Console.WriteLine("Hosted by {0} ({1}/{2}), distance: {3}km, latency: {4}ms", server.Sponsor, server.Name,
+                server.Country, (int)server.Distance / 1000, server.Latency);
+        }
+
+        private static void PrintSpeed(string type, double speed)
+        {
+            if (speed > 1024)
+            {
+                Console.WriteLine("{0} speed: {1} Mbps", type, Math.Round(speed / 1024, 2));
+            }
+            else
+            {
+                Console.WriteLine("{0} speed: {1} Kbps", type, Math.Round(speed, 2));
+            }
+        }
+    }
+}

--- a/NSpeedTest.sln
+++ b/NSpeedTest.sln
@@ -1,13 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26403.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest", ".\NSpeedTest\NSpeedTest.csproj", "{B1886B34-0DE4-4C16-8073-CC12E7571D58}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest", "NSpeedTest\NSpeedTest.csproj", "{B1886B34-0DE4-4C16-8073-CC12E7571D58}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest.Tests", ".\NSpeedTest.Tests\NSpeedTest.Tests.csproj", "{33672FA6-5014-4BA0-B9A8-62CA932701C0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest.Tests", "NSpeedTest.Tests\NSpeedTest.Tests.csproj", "{33672FA6-5014-4BA0-B9A8-62CA932701C0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest.Client", ".\NSpeedTest.Client\NSpeedTest.Client.csproj", "{E82DE6B4-CD53-4B05-97D7-6C490F4F64A7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest.Client", "NSpeedTest.Client\NSpeedTest.Client.csproj", "{E82DE6B4-CD53-4B05-97D7-6C490F4F64A7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest.Standard", "NSpeedTest.Standard\NSpeedTest.Standard.csproj", "{03CD46AF-C6FB-4E5A-8082-2FF2140CD5CE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NSpeedTest.StandardClient", "NSpeedTest.StandardClient\NSpeedTest.StandardClient.csproj", "{9150C07B-FDE7-44F8-BB12-7CDD4D4FCEC9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +31,14 @@ Global
 		{E82DE6B4-CD53-4B05-97D7-6C490F4F64A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E82DE6B4-CD53-4B05-97D7-6C490F4F64A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E82DE6B4-CD53-4B05-97D7-6C490F4F64A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03CD46AF-C6FB-4E5A-8082-2FF2140CD5CE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03CD46AF-C6FB-4E5A-8082-2FF2140CD5CE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03CD46AF-C6FB-4E5A-8082-2FF2140CD5CE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03CD46AF-C6FB-4E5A-8082-2FF2140CD5CE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9150C07B-FDE7-44F8-BB12-7CDD4D4FCEC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9150C07B-FDE7-44F8-BB12-7CDD4D4FCEC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9150C07B-FDE7-44F8-BB12-7CDD4D4FCEC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9150C07B-FDE7-44F8-BB12-7CDD4D4FCEC9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
I've started the port non-destructively. Added two new projects NSpeedTest.Standard (.NET Standard 1.6) and NSpeedTest.StandardClient (.NET Core 1.1).

It's currently building and running but I'm getting an empty string back from the first get config call. Want to help out with the port?

Once the port is complete we can either rename them and delete the others or release it as a second Nuget package or something.